### PR TITLE
feat: Add copy to clipboard for email addresses

### DIFF
--- a/src/views/contactView.jsx
+++ b/src/views/contactView.jsx
@@ -1,36 +1,78 @@
+import React, { useState } from "react";
 import "/src/style.css";
-import { Box, Card, CardContent, Typography, Button, Stack, Paper } from '@mui/material';
+import { Box, Card, CardContent, Typography, Button, Stack, Paper, IconButton, Snackbar } from '@mui/material';
 import Divider from '@mui/material/Divider';
 import EmailIcon from '@mui/icons-material/Email';
 import HomeIcon from '@mui/icons-material/Home';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
-const EmailCard = ({ title, email }) => (
-  <Card 
-    variant="outlined" 
-    sx={{
-      mb: 2,
-      transition: 'transform 0.2s, box-shadow 0.2s',
-      '&:hover': {
-        transform: 'translateY(-4px)',
-        boxShadow: 3,
-      }
-    }}
-  >
-    <CardContent>
-      <Stack direction="row" alignItems="center" spacing={2}>
-        <EmailIcon color="primary" sx={{ fontSize: 30 }} />
-        <Box>
-          <Typography variant="subtitle2" color="text.secondary">
-            {title}
-          </Typography>
-          <Typography variant="h6">
-            {email.replace(' [at] ', '@')}
-          </Typography>
-        </Box>
-      </Stack>
-    </CardContent>
-  </Card>
-);
+const EmailCard = ({ title, email }) => {
+    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState("");
+
+    const handleCopyEmail = () => {
+        const fullEmail = email.replace(' [at] ', '@');
+        navigator.clipboard.writeText(fullEmail)
+            .then(() => {
+                setSnackbarMessage("Email copied to clipboard!");
+                setOpenSnackbar(true);
+            })
+            .catch(err => {
+                setSnackbarMessage("Failed to copy email.");
+                setOpenSnackbar(true);
+                console.error('Failed to copy email: ', err);
+            });
+    };
+
+    const handleCloseSnackbar = (event, reason) => {
+        if (reason === 'clickaway') {
+            return;
+        }
+        setOpenSnackbar(false);
+    };
+
+    return (
+        <>
+            <Card 
+                variant="outlined" 
+                sx={{
+                    mb: 2,
+                    transition: 'transform 0.2s, box-shadow 0.2s',
+                    '&:hover': {
+                        transform: 'translateY(-4px)',
+                        boxShadow: 3,
+                    }
+                }}
+            >
+                <CardContent>
+                    <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+                        <Stack direction="row" alignItems="center" spacing={2}>
+                            <EmailIcon color="primary" sx={{ fontSize: 30 }} />
+                            <Box>
+                                <Typography variant="subtitle2" color="text.secondary">
+                                    {title}
+                                </Typography>
+                                <Typography variant="h6">
+                                    {email.replace(' [at] ', '@')}
+                                </Typography>
+                            </Box>
+                        </Stack>
+                        <IconButton onClick={handleCopyEmail} aria-label="copy email">
+                            <ContentCopyIcon />
+                        </IconButton>
+                    </Stack>
+                </CardContent>
+            </Card>
+            <Snackbar
+                open={openSnackbar}
+                autoHideDuration={3000}
+                onClose={handleCloseSnackbar}
+                message={snackbarMessage}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            />
+        </>
+    );
+};
 
 const ContactView = function contactview() {
   return (


### PR DESCRIPTION
Implemented a "Copy to Clipboard" feature in the ContactView.

- Added a copy icon button next to each email address on the contact page.
- Clicking the button copies the email address (formatted with '@') to your clipboard.
- A Snackbar notification provides feedback to you, confirming that the email has been copied or if an error occurred.
- This enhances your experience by making it easier to copy contact information.